### PR TITLE
Client Updates Automatically.

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -39,8 +39,9 @@ def createHabit():
     response_json = flask.request.json
     addUserHabit(response_json)
 
-    #TODO: update to something more meaningful
-    return flask.jsonify({"status":'success'}) 
+    DATA = {"habits": getWeekAndHabits()}
+    data = json.dumps(DATA)
+    return(data)
 
 @bp.route('/update-completion', methods=["POST"])
 def updateCompletionDate():
@@ -51,8 +52,9 @@ def updateCompletionDate():
     elif response_json['action'] == 'removing':
         removeCompletionDate(response_json)
         
-    #TODO: update to something more meaningful
-    return flask.jsonify({"status":'success'}) 
+    DATA = {"habits": getWeekAndHabits()}
+    data = json.dumps(DATA)
+    return(data)
 
 app.register_blueprint(bp)
 

--- a/src/App.js
+++ b/src/App.js
@@ -125,6 +125,31 @@ function App() {
     handleModalClose();
   }
 
+  //moved to App.js so that it could access the habit state
+  function handleSquareClick(title, date, action) {
+    console.log("square clicked");
+
+    console.log(
+      JSON.stringify({
+        "action": action,
+        "title": title,
+        "date": date,
+      }),
+    );
+
+    //Sends habit information to server in JSON form.
+    fetch('/update-completion', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        "action": action,
+        "title": title,
+        "date": date,
+      }),
+    }).then(response => response.json());
+  }
 
   return (
     <>
@@ -133,7 +158,7 @@ function App() {
         titleInput={titleInput} categoryInput={categoryInput} checkBoxIds={checkBoxIds} />
 
       <br /><br />
-      <HabitTable habits={habits} />
+      <HabitTable habits={habits} onSquareClick={handleSquareClick} />
       <a href="/logout"><Button variant="outline-success" id="logout">Log Out!</Button></a>
     </>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -115,27 +115,23 @@ function App() {
       body: JSON.stringify({
         "title": title,
         "category": category,
-        "target_days_str": target_days_str
+        "target_days_str": target_days_str,
       }),
-    }).then(response => response.json());
+    }).then((response) => response.json())
+      .then((data) => {
+        setHabits(data.habits);
+      });
+
 
     //Clears text fields and hides modal
     titleInput.current.value = "";
     categoryInput.current.value = "";
     handleModalClose();
+
   }
 
   //moved to App.js so that it could access the habit state
   function handleSquareClick(title, date, action) {
-    console.log("square clicked");
-
-    console.log(
-      JSON.stringify({
-        "action": action,
-        "title": title,
-        "date": date,
-      }),
-    );
 
     //Sends habit information to server in JSON form.
     fetch('/update-completion', {
@@ -148,7 +144,10 @@ function App() {
         "title": title,
         "date": date,
       }),
-    }).then(response => response.json());
+    }).then(response => response.json())
+      .then((data) => {
+        setHabits(data.habits);
+      });
   }
 
   return (

--- a/src/HabitTable.js
+++ b/src/HabitTable.js
@@ -37,30 +37,6 @@ function HabitRow(props) {
 export function HabitTable(props) {
     console.log(props.habits)
 
-    function handleSquareClick(title, date, action) {
-        console.log("square clicked");
-
-        console.log(
-            JSON.stringify({
-                "action": action,
-                "title": title,
-                "date": date,
-            }),
-        );
-
-        //Sends habit information to server in JSON form.
-        fetch('/update-completion', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                "action": action,
-                "title": title,
-                "date": date,
-            }),
-        }).then(response => response.json());
-    }
     return (
         <Table striped bordered className="weekly-view">
             <thead>
@@ -77,7 +53,7 @@ export function HabitTable(props) {
             </thead>
             <tbody>
                 {props.habits.map((habit) => (
-                    <HabitRow habit={habit} numOfDays={7} onSquareClick={handleSquareClick} />
+                    <HabitRow habit={habit} numOfDays={7} onSquareClick={props.onSquareClick} />
                 ))}
             </tbody>
         </Table>


### PR DESCRIPTION
When the user interacts with a habit, whether it is creating it or updating a completion date, the UI updates right away.
- Moved `handleSquareClick` to App.js so that when the fetch call is made it can receive the updated habits dictionary. It can then use `setHabits` to update the `habits` state and rerender the page.
- Updated the return lines for the `/create` and `/update-completion` endpoints so that it returns the updated user habits information rather than just "success".
- When a user updates completion dates, sometimes the habits ordering changes in the table. This can be fixed with some kind of sorting later on. See https://github.com/habbit-tracker/habit-tracker/issues/20#issue-1058768885

*Test Plan*
Before Change: https://recordit.co/SlMWLrbTHg
After Change: https://recordit.co/8j5zdVPdC0